### PR TITLE
Fix meson complains that 'it Could not detect Ninja v1.5 or newer'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,9 @@ addons:
       - cmake
       - python3-pip
       - python3-setuptools
-      - ninja-build
 
 install:
-  - pip3 install meson
+  - pip3 install meson ninja
 
 before_script:
   - git clone --depth 1 https://github.com/aws/aws-sdk-cpp.git -b 1.7.202


### PR DESCRIPTION
Mitigating [this issue with meson](https://github.com/mesonbuild/meson/issues/6867) that affects the [build](https://travis-ci.org/github/amzn/amazon-s3-gst-plugin/builds/700962905)

*Description of changes:*
Installing ninja via pip3.

