### PR TITLE
Add option to add canned ACL to the S3 Multipart uploader

### DIFF
--- a/src/gsts3multipartuploader.cpp
+++ b/src/gsts3multipartuploader.cpp
@@ -325,6 +325,7 @@ private:
 
     Aws::String _bucket;
     Aws::String _key;
+    Aws::String _acl = Aws::String("NOT_SET");
 
     Aws::S3::Model::CreateMultipartUploadOutcome _upload_outcome;
 
@@ -354,6 +355,7 @@ private:
 MultipartUploader::MultipartUploader(const GstS3UploaderConfig *config) :
     _bucket(config->bucket),
     _key(config->key),
+    _acl(config->acl),
     _part_states(std::make_shared<PartStateCollection>(false)),
     _init_sdk(config->init_aws_sdk)
 {
@@ -442,8 +444,10 @@ bool MultipartUploader::_init_uploader(const GstS3UploaderConfig * config)
     _init_buffer_manager(config->buffer_count, config->buffer_size);
 
     Aws::S3::Model::CreateMultipartUploadRequest upload_request;
+    Aws::S3::Model::ObjectCannedACL acl = Aws::S3::Model::ObjectCannedACLMapper::GetObjectCannedACLForName(_acl);
     upload_request.SetBucket(_bucket);
     upload_request.SetKey(_key);
+    upload_request.SetACL(std::move(acl));
 
     if (is_null_or_empty(config->content_type))
     {

--- a/src/gsts3multipartuploader.cpp
+++ b/src/gsts3multipartuploader.cpp
@@ -444,7 +444,7 @@ bool MultipartUploader::_init_uploader(const GstS3UploaderConfig * config)
     _init_buffer_manager(config->buffer_count, config->buffer_size);
 
     Aws::S3::Model::CreateMultipartUploadRequest upload_request;
-    Aws::S3::Model::ObjectCannedACL acl = Aws::S3::Model::ObjectCannedACLMapper::GetObjectCannedACLForName(_acl);
+    Aws::S3::Model::ObjectCannedACL acl = Aws::S3::Model::ObjectCannedACLMapper::GetObjectCannedACLForName(Aws::String(_acl));
     upload_request.SetBucket(_bucket);
     upload_request.SetKey(_key);
     upload_request.SetACL(std::move(acl));

--- a/src/gsts3multipartuploader.cpp
+++ b/src/gsts3multipartuploader.cpp
@@ -443,7 +443,6 @@ bool MultipartUploader::_init_uploader(const GstS3UploaderConfig * config)
     _init_buffer_manager(config->buffer_count, config->buffer_size);
 
     Aws::S3::Model::CreateMultipartUploadRequest upload_request;
-    Aws::S3::Model::ObjectCannedACL acl = Aws::S3::Model::ObjectCannedACLMapper::GetObjectCannedACLForName(_acl);
     upload_request.SetBucket(_bucket);
     upload_request.SetKey(_key);
     

--- a/src/gsts3multipartuploader.cpp
+++ b/src/gsts3multipartuploader.cpp
@@ -448,7 +448,7 @@ bool MultipartUploader::_init_uploader(const GstS3UploaderConfig * config)
     
     if (!is_null_or_empty(config->acl))
     {
-        _acl = Aws::S3::Model::ObjectCannedACLMapper::GetObjectCannedACLForName(config->acl);
+        _acl = Aws::S3::Model::ObjectCannedACLMapper::GetObjectCannedACLForName(Aws::String(config->acl));
         upload_request.SetACL(_acl);
     }
 

--- a/src/gsts3sink.c
+++ b/src/gsts3sink.c
@@ -114,7 +114,7 @@ gst_s3_sink_class_init (GstS3SinkClass * klass)
           "The key of the file to write", NULL,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
 
-  g_object_class_install_property (gobject_class, PROP_KEY,
+  g_object_class_install_property (gobject_class, PROP_ACL,
       g_param_spec_string ("acl", "S3 object acl",
           "The canned acl for s3 object to upload", NULL,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));

--- a/src/gsts3sink.c
+++ b/src/gsts3sink.c
@@ -57,6 +57,7 @@ enum
   PROP_0,
   PROP_BUCKET,
   PROP_KEY,
+  PROP_ACL,
   PROP_CONTENT_TYPE,
   PROP_CA_FILE,
   PROP_REGION,
@@ -113,6 +114,11 @@ gst_s3_sink_class_init (GstS3SinkClass * klass)
           "The key of the file to write", NULL,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_KEY,
+      g_param_spec_string ("acl", "S3 object acl",
+          "The canned acl for s3 object to upload", NULL,
+          G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
+
   g_object_class_install_property (gobject_class, PROP_CONTENT_TYPE,
       g_param_spec_string ("content-type", "Content type",
           "The content type of a stream", NULL,
@@ -123,7 +129,7 @@ gst_s3_sink_class_init (GstS3SinkClass * klass)
           "A path to a CA file", NULL,
           G_PARAM_READWRITE | GST_PARAM_MUTABLE_READY | G_PARAM_STATIC_STRINGS));
 
-g_object_class_install_property (gobject_class, PROP_REGION,
+  g_object_class_install_property (gobject_class, PROP_REGION,
       g_param_spec_string ("region", "AWS Region",
           "An AWS region (e.g. eu-west-2). Leave empty for region-autodetection "
           "(Please note region-autodetection requires an extra network call)", NULL,
@@ -208,6 +214,7 @@ gst_s3_sink_release_config (GstS3UploaderConfig * config)
   g_free (config->region);
   g_free (config->bucket);
   g_free (config->key);
+  g_free (config->acl);
   g_free (config->content_type);
   g_free (config->ca_file);
   g_free (config->aws_sdk_endpoint);
@@ -262,6 +269,10 @@ gst_s3_sink_set_property (GObject * object, guint prop_id,
     case PROP_KEY:
       gst_s3_sink_set_string_property (sink, g_value_get_string (value),
           &sink->config.key, "key");
+      break;
+    case PROP_ACL:
+      gst_s3_sink_set_string_property (sink, g_value_get_string (value),
+          &sink->config.acl, "acl");
       break;
     case PROP_CONTENT_TYPE:
       gst_s3_sink_set_string_property (sink, g_value_get_string (value),
@@ -323,6 +334,9 @@ gst_s3_sink_get_property (GObject * object, guint prop_id, GValue * value,
       break;
     case PROP_KEY:
       g_value_set_string (value, sink->config.key);
+      break;
+    case PROP_ACL:
+      g_value_set_string (value, sink->config.acl);
       break;
     case PROP_CONTENT_TYPE:
       g_value_set_string (value, sink->config.content_type);

--- a/src/gsts3uploaderconfig.h
+++ b/src/gsts3uploaderconfig.h
@@ -36,6 +36,7 @@ typedef struct {
   gchar * region;
   gchar * bucket;
   gchar * key;
+  gchar * acl;
   gchar * content_type;
   gchar * ca_file;
   GstAWSCredentials * credentials;
@@ -49,7 +50,7 @@ typedef struct {
 } GstS3UploaderConfig;
 
 #define GST_S3_UPLOADER_CONFIG_INIT (GstS3UploaderConfig) { \
-  NULL, NULL, NULL, NULL, NULL, NULL, \
+  NULL, NULL, NULL, NULL, NULL, NULL, NULL, \
   GST_S3_UPLOADER_CONFIG_DEFAULT_BUFFER_SIZE, \
   GST_S3_UPLOADER_CONFIG_DEFAULT_BUFFER_COUNT, \
   GST_S3_UPLOADER_CONFIG_DEFAULT_INIT_AWS_SDK, \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added option to pass in an ACL to the s3sink element so permissions on s3 objects can be changed

ACL can be added with the following options:

- private
- public-read
- public-read-write
- authenticated-read
- aws-exec-read
- bucket-owner-read
- bucket-owner-full-control

Tests:
- Without setting ACL, uses default,
- With setting incorrect ACL, s3 sink fails to initialise
- With setting correct ACL, canned ACL is set correctly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
