### PR TITLE
fix gst log formatting arguments

### DIFF
--- a/src/gsts3multipartuploader.cpp
+++ b/src/gsts3multipartuploader.cpp
@@ -71,7 +71,7 @@ public:
 
     void LogStream(Aws::Utils::Logging::LogLevel log_level, const char* tag, const Aws::OStringStream &message_stream) override
     {
-        Log(log_level, tag, message_stream.str().c_str());
+        Log(log_level, tag, "%s", message_stream.str().c_str());
     }
 
     void Flush() override

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,7 +38,7 @@ gst_s3_elements = library('gsts3elements',
 
 s3elements_dep = declare_dependency(link_with : gst_s3_elements,
   include_directories : [include_directories('.')],
-  dependencies : [gst_dep, gst_base_dep]
+  dependencies : [gst_dep, gst_base_dep, aws_cpp_sdk_s3_dep, aws_cpp_sdk_sts_dep]
 )
 
 install_headers(gst_s3_public_headers, subdir : 'gstreamer-1.0/gst/aws')


### PR DESCRIPTION
passing a log string in a printf format specifier can do bad things if
e.g the message contains printf arguments as may occur when logging
random data received from e.g. libcurl.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
