### PR TITLE
Change Python3 version to fix meson build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
       - gstreamer1.0-plugins-base
       - libgstreamer1.0-dev
       - cmake
+      - python3.6
       - python3-pip
       - python3-setuptools
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change Python3 version to fix meson build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
