### PR TITLE
Change travis python version to 3.7.1 to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ language:
   - c
   - cpp
 
+env:
+  global:
+    - PATH=/opt/python/3.7.1/bin:$PATH
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change travis python version to 3.7.1 to fix build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
