### PR TITLE
Fixed linking error for AWS SDK 1.16.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,10 @@ gst_check_dep = dependency('gstreamer-check-1.0', version : gst_req,
   fallback : ['gstreamer', 'gst_check_dep'])
 aws_cpp_sdk_s3_dep = dependency('aws-cpp-sdk-s3', version : aws_cpp_sdk_req)
 aws_cpp_sdk_sts_dep = dependency('aws-cpp-sdk-sts', version : aws_cpp_sdk_req)
+cpp = meson.get_compiler('cpp')
+aws_c_common_dep = cpp.find_library('aws-c-common', required: true)
+aws_crt_cpp_dep=cpp.find_library('aws-crt-cpp', required:true)
+
 
 configinc = include_directories('.')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -11,7 +11,7 @@ gst_s3_public_headers = [
 
 credentials = library('gstawscredentials-@0@'.format(apiversion),
   ['gstawscredentials.cpp'],
-  dependencies : [aws_cpp_sdk_sts_dep, gst_dep],
+  dependencies : [aws_cpp_sdk_sts_dep,  gst_dep, aws_c_common_dep, aws_crt_cpp_dep],
   install : true
 )
 
@@ -30,7 +30,7 @@ multipart_uploader_dep = declare_dependency(link_with : multipart_uploader,
 
 gst_s3_elements = library('gsts3elements',
   gst_s3_elements_sources,
-  dependencies : [gst_dep, gst_base_dep, multipart_uploader_dep, credentials_dep],
+  dependencies : [gst_dep, gst_base_dep, multipart_uploader_dep, credentials_dep, aws_c_common_dep, aws_crt_cpp_dep],
   include_directories : [configinc],
   install : true,
   install_dir : plugins_install_dir,


### PR DESCRIPTION
Fix for linking error with AWS SDK version 1.9.19

*Issue #, if available:*
https://github.com/amzn/amazon-s3-gst-plugin/issues/18

*Description of changes:*
added dependency for libraries:
Library aws-c-common found: YES
Library aws-crt-cpp found: YES

```
The Meson build system
Version: 0.58.0
Source dir: /home/makhlu/amazon-s3-gst-plugin
Build dir: /home/makhlu/amazon-s3-gst-plugin/buld
Build type: native build
Project name: amazon-s3-gst-plugin
Project version: 0.1.0
C compiler for the host machine: cc (gcc 9.3.0 "cc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0")
C linker for the host machine: cc ld.bfd 2.34
C++ compiler for the host machine: c++ (gcc 9.3.0 "c++ (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0")
C++ linker for the host machine: c++ ld.bfd 2.34
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: /usr/bin/pkg-config (0.29.1)
Run-time dependency glib-2.0 found: YES 2.64.6
Run-time dependency gstreamer-1.0 found: YES 1.16.2
Run-time dependency gstreamer-base-1.0 found: YES 1.16.2
Run-time dependency gstreamer-check-1.0 found: YES 1.16.2
Run-time dependency aws-cpp-sdk-s3 found: YES 1.9.19
Run-time dependency aws-cpp-sdk-sts found: YES 1.9.19
Library aws-c-common found: YES
Library aws-crt-cpp found: YES
Configuring config.h using configuration
Configuring gstreamer-aws-1.0.pc using configuration
Build targets in project: 4

Found ninja-1.10.0 at /usr/bin/ninja
```
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
