### PR TITLE
Changes required fix build on Windows with MSVC

### DIFF
--- a/src/gstawscredentials.cpp
+++ b/src/gstawscredentials.cpp
@@ -18,8 +18,6 @@
  */
 #include "gstawscredentials.hpp"
 
-#include <gst/gst.h>
-
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/sts/model/AssumeRoleRequest.h>
 #include <aws/sts/STSClient.h>

--- a/src/gstawscredentials.h
+++ b/src/gstawscredentials.h
@@ -19,18 +19,22 @@
 #ifndef __GST_AWS_CREDENTIALS_H__
 #define __GST_AWS_CREDENTIALS_H__
 
-#include <glib-object.h>
+#include <gst/gst.h>
 
 G_BEGIN_DECLS
 
 typedef struct _GstAWSCredentials GstAWSCredentials;
 
+GST_EXPORT
 GstAWSCredentials * gst_aws_credentials_new_default (void);
 
+GST_EXPORT
 GstAWSCredentials * gst_aws_credentials_copy (GstAWSCredentials * credentials);
 
+GST_EXPORT
 void gst_aws_credentials_free (GstAWSCredentials * credentials);
 
+GST_EXPORT
 GType gst_aws_credentials_get_type (void);
 
 #define GST_TYPE_AWS_CREDENTIALS \

--- a/src/gstawscredentials.hpp
+++ b/src/gstawscredentials.hpp
@@ -26,9 +26,11 @@
 
 using GstAWSCredentialsProviderFactory = std::function<std::unique_ptr<Aws::Auth::AWSCredentialsProvider>()>;
 
+GST_EXPORT
 GstAWSCredentials *
 gst_aws_credentials_new (GstAWSCredentialsProviderFactory factory);
 
+GST_EXPORT
 std::unique_ptr<Aws::Auth::AWSCredentialsProvider>
 gst_aws_credentials_create_provider (GstAWSCredentials * credentials);
 

--- a/src/gsts3multipartuploader.cpp
+++ b/src/gsts3multipartuploader.cpp
@@ -40,8 +40,6 @@
 
 #include <gst/gst.h>
 
-GST_DEBUG_CATEGORY_EXTERN(gst_s3_sink_debug);
-
 namespace gst
 {
 namespace aws

--- a/src/gsts3multipartuploader.h
+++ b/src/gsts3multipartuploader.h
@@ -23,6 +23,8 @@
 
 G_BEGIN_DECLS
 
+GST_DEBUG_CATEGORY_EXTERN(gst_s3_sink_debug);
+
 typedef struct _GstS3MultipartUploader GstS3MultipartUploader;
 
 GstS3Uploader * gst_s3_multipart_uploader_new (const GstS3UploaderConfig * config);

--- a/src/gsts3sink.h
+++ b/src/gsts3sink.h
@@ -65,6 +65,7 @@ struct _GstS3SinkClass {
   GstBaseSinkClass parent_class;
 };
 
+GST_EXPORT
 GType gst_s3_sink_get_type (void);
 
 G_END_DECLS

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,9 +9,14 @@ gst_s3_public_headers = [
   'gstawscredentials.hpp'
 ]
 
+# Export symbols when building, import when not. This is optional on Linux
+# / macOS, but necessary on Windows otherwise .lib files will not be generated.
+symbol_export_define = ['-DGST_EXPORTS']
+
 credentials = library('gstawscredentials-@0@'.format(apiversion),
   ['gstawscredentials.cpp'],
   dependencies : [aws_cpp_sdk_sts_dep, gst_dep],
+  cpp_args: symbol_export_define,
   install : true
 )
 
@@ -30,6 +35,8 @@ multipart_uploader_dep = declare_dependency(link_with : multipart_uploader,
 
 gst_s3_elements = library('gsts3elements',
   gst_s3_elements_sources,
+  cpp_args: symbol_export_define,
+  c_args: symbol_export_define,
   dependencies : [gst_dep, gst_base_dep, multipart_uploader_dep, credentials_dep],
   include_directories : [configinc],
   install : true,


### PR DESCRIPTION
```
windows: Export/import library symbols for linking

Without this, gstawscredentials-1.0.lib is not generated by LINK.exe
because no symbols are exported, and compilation fails.

We can simply use the symbols exported by gstreamer in gst/gstconfig.h
to do this correctly.

Related to https://github.com/amzn/amazon-s3-gst-plugin/issues/13
```

```
windows: Fix debug category linkage

Fixes this linker error:

libmultipartuploader.a(gsts3multipartuploader.cpp.obj) : error LNK2001: unresolved external symbol "struct _GstDebugCategory * gst_s3_sink_debug" (?gst_s3_sink_debug@@3PEAU_GstDebugCategory@@EA)
src/gsts3elements.dll : fatal error LNK1120: 1 unresolved externals

Essentially, the debug category is a C symbol, so put it inside
G_BEGIN_DECLS so that it doesn't get C++ symbol mangling.
```

This PR plus https://github.com/aws/aws-sdk-cpp/pull/1839 fixes https://github.com/amzn/amazon-s3-gst-plugin/issues/13

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.