### PR TITLE
Fix build on macos

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'
-        run: >-
+        run: |
           sudo apt-get update
-
-          sudo apt-get install -y curl libcurl4-openssl-dev cmake gstreamer1.0-plugins-base
-          libgstreamer1.0-dev python3-pip python3-setuptools
+          # remove libunwind-*-dev from the runner to avoid conflicts with a dependency of libgstreamer1.0-dev
+          sudo apt-get remove -y libunwind-14-dev libunwind-13-dev
+          sudo apt-get install -y curl libcurl4-openssl-dev cmake gstreamer1.0-plugins-base libgstreamer1.0-dev python3-pip python3-setuptools
       - uses: actions/checkout@v3
       - run: pip3 install meson ninja
       - run: 'git clone --recurse-submodules --depth 1 https://github.com/aws/aws-sdk-cpp.git -b 1.10.30'

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-22.04
     steps:
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-latest
     steps:
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
     steps:
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'
@@ -21,6 +22,13 @@ jobs:
           # remove libunwind-*-dev from the runner to avoid conflicts with a dependency of libgstreamer1.0-dev
           sudo apt-get remove -y libunwind-14-dev libunwind-13-dev
           sudo apt-get install -y curl libcurl4-openssl-dev cmake gstreamer1.0-plugins-base libgstreamer1.0-dev python3-pip python3-setuptools
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          # install python 3.11 explicitly to avoid it failing to overwrite the pre-installed python when it's pulled in as a dependency
+          brew install --overwrite python@3.11
+          brew install --overwrite gstreamer
       - uses: actions/checkout@v3
       - run: pip3 install meson ninja
       - run: 'git clone --recurse-submodules --depth 1 https://github.com/aws/aws-sdk-cpp.git -b 1.10.30'

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,8 @@ gst_s3_version = meson.project_version()
 
 apiversion = '1.0'
 
+is_macos = (host_machine.system() == 'darwin')
+
 glib_dep = dependency('glib-2.0')
 gst_dep = dependency('gstreamer-1.0', version : gst_req,
   fallback : ['gstreamer', 'gst_dep'])
@@ -17,8 +19,9 @@ gst_base_dep = dependency('gstreamer-base-1.0', version : gst_req,
   fallback : ['gstreamer', 'gst_base_dep'])
 gst_check_dep = dependency('gstreamer-check-1.0', version : gst_req,
   fallback : ['gstreamer', 'gst_check_dep'])
-aws_cpp_sdk_s3_dep = dependency('aws-cpp-sdk-s3', version : aws_cpp_sdk_req)
-aws_cpp_sdk_sts_dep = dependency('aws-cpp-sdk-sts', version : aws_cpp_sdk_req)
+# use static linker args on macos as the dylibs don't include the crt symbols
+aws_cpp_sdk_s3_dep = dependency('aws-cpp-sdk-s3', version : aws_cpp_sdk_req, static : is_macos)
+aws_cpp_sdk_sts_dep = dependency('aws-cpp-sdk-sts', version : aws_cpp_sdk_req, static : is_macos)
 
 configinc = include_directories('.')
 

--- a/tests/check/meson.build
+++ b/tests/check/meson.build
@@ -1,11 +1,19 @@
 element_tests = ['s3sink.c']
 
+# create a dependency that omits the compiler args because clang refuses
+# to compile c files with cpp args
+c_safe_s3elements_dep = s3elements_dep.partial_dependency(
+  sources: true,
+  includes: true,
+  links: true
+)
+
 foreach test_file : element_tests
   test_name = test_file.split('.').get(0).underscorify()
 
   exe = executable(test_name, test_file,
     include_directories : [configinc],
-    dependencies : [s3elements_dep, gst_check_dep]
+    dependencies : [c_safe_s3elements_dep, gst_check_dep]
   )
 
   env = environment()

--- a/tests/check/s3sink.c
+++ b/tests/check/s3sink.c
@@ -116,6 +116,30 @@ push_bytes_finalize:
 #define PUSH_BYTES(pad, num_bytes) fail_if (!push_bytes(pad, num_bytes, GST_FLOW_OK))
 #define PUSH_BYTES_FAILURE(pad, num_bytes) fail_if (!push_bytes(pad, num_bytes, GST_FLOW_ERROR))
 
+/**
+ * @brief Before pushing buffers/bytes one must send a stream start and a segment declaration
+ * or else critical errors will occur.
+ *
+ * @param srcpad The pad to send the events onto.
+ * @param stream_name nullable, the name of the stream
+ * @return gboolean TRUE if the events were set; FALSE otherwise.
+ */
+static gboolean
+prepare_to_push_bytes (GstPad *srcpad, const char* stream_name) {
+  gboolean ret = TRUE;
+  GstSegment segment;
+  const char* name = (stream_name) ? stream_name : "test";
+
+  gst_segment_init(&segment, GST_FORMAT_BYTES);
+  ret = (
+    gst_pad_push_event(srcpad, gst_event_new_stream_start(name))
+    &&
+    gst_pad_push_event(srcpad, gst_event_new_segment(&segment))
+  );
+
+  return ret;
+}
+
 static GstElement *
 setup_default_s3_sink (GstS3Uploader *uploader)
 {
@@ -253,6 +277,8 @@ GST_START_TEST (test_send_eos_should_flush_buffer)
   ret = gst_element_set_state (sink, GST_STATE_PLAYING);
   fail_unless (ret == GST_STATE_CHANGE_ASYNC);
 
+  fail_unless(TRUE == prepare_to_push_bytes(srcpad, NULL));
+
   PUSH_BYTES(srcpad, 10);
 
   sinkpad = gst_element_get_static_pad (sink, "sink");
@@ -286,6 +312,8 @@ GST_START_TEST (test_push_buffer_should_flush_buffer_if_reaches_limit)
   ret = gst_element_set_state (sink, GST_STATE_PLAYING);
   fail_unless (ret == GST_STATE_CHANGE_ASYNC);
 
+  fail_unless(TRUE == prepare_to_push_bytes(srcpad, NULL));
+
   for (idx = 0; idx < 16; idx++) {
     PUSH_BYTES (srcpad, 1024 * 1024);
   }
@@ -316,6 +344,8 @@ GST_START_TEST (test_query_position)
 
   ret = gst_element_set_state (sink, GST_STATE_PLAYING);
   fail_unless (ret == GST_STATE_CHANGE_ASYNC);
+
+  fail_unless(TRUE == prepare_to_push_bytes(srcpad, NULL));
 
   PUSH_BYTES(srcpad, bytes_to_write);
 
@@ -375,6 +405,8 @@ GST_START_TEST (test_upload_part_failure)
   ret = gst_element_set_state (sink, GST_STATE_PLAYING);
   fail_unless (ret == GST_STATE_CHANGE_ASYNC);
 
+  fail_unless(TRUE == prepare_to_push_bytes(srcpad, NULL));
+
   PUSH_BYTES(srcpad, bytes_to_write);
   PUSH_BYTES(srcpad, bytes_to_write);
   PUSH_BYTES_FAILURE(srcpad, bytes_to_write);
@@ -398,6 +430,8 @@ GST_START_TEST (test_push_empty_buffer)
 
   ret = gst_element_set_state (sink, GST_STATE_PLAYING);
   fail_unless (ret == GST_STATE_CHANGE_ASYNC);
+
+  fail_unless(TRUE == prepare_to_push_bytes(srcpad, NULL));
 
   fail_unless_equals_int (gst_pad_push (srcpad, gst_buffer_new ()), GST_FLOW_OK);
 


### PR DESCRIPTION
Work around a couple of issues in the AWS SDK pkgconfig files on macos:

1. Clang fails with `error: invalid argument '-std=c++11' not allowed with 'C'` when compiling the C test file. The flag comes from the SDK pkgconfig file, but on linux gcc only emits a warning and ignores the flag.

2. The SDK dylibs aren't statically linked with their CRT dependency on macos (they are on linux), resulting in undefined symbol errors when linking against them (because the linker flags in pkgconfig don't include the CRT lib).

*Issue #, if available:*
#33 

*Description of changes:*
1. Create a partial dependency that excludes compiler args for use when compiling the C test file
2. Use static linker args for the SDK dependency on macos so the build links against the required CRT libs (`-laws-crt-cpp`, etc)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
